### PR TITLE
Modified TCP Port width

### DIFF
--- a/src/main/java/modbuspal/main/ModbusPalPane.java
+++ b/src/main/java/modbuspal/main/ModbusPalPane.java
@@ -502,7 +502,7 @@ implements ModbusPalXML, WindowListener, ModbusPalListener, ModbusLinkListener
         tcpIpSettingsPanel.add(jLabel1, gridBagConstraints);
 
         portTextField.setText("502");
-        portTextField.setPreferredSize(new java.awt.Dimension(40, 20));
+        portTextField.setPreferredSize(new java.awt.Dimension(80, 20));
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.insets = new java.awt.Insets(5, 2, 5, 5);
         tcpIpSettingsPanel.add(portTextField, gridBagConstraints);


### PR DESCRIPTION
Noticed a bug while using the ControlThings platform at SANS 2019 in the ICS410 course.  Using port 10502 for example would not be displayed correctly due to the width of the textbox control being too small.